### PR TITLE
highlight delayed expansion variables

### DIFF
--- a/bat.nanorc
+++ b/bat.nanorc
@@ -17,6 +17,7 @@ icolor brightwhite "\"[^\"]*\""
 
 ## Variables
 icolor brightyellow "\%[^\%]*\%"
+icolor brightyellow "\![^\!]*\!"
 
 ## Parameters that are normally %x in cmd
 icolor brightred "%%."


### PR DESCRIPTION
when using delayed expansion with batch, variables are used like !this! instead of like %this%